### PR TITLE
fix(js): point API_BASE to Railway production URL

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -1,9 +1,9 @@
 // Bridge Storage Website Configuration
 const BRIDGE_CONFIG = {
-    // API base URL — change for local development
-    // Production: https://bridge-ai.your-domain.com
+    // API base URL
+    // Production: https://bridge-ai-production-55f9.up.railway.app
     // Local dev:  http://localhost:8000
-    API_BASE: 'http://localhost:8000',
+    API_BASE: 'https://bridge-ai-production-55f9.up.railway.app',
 
     // Site info
     SITE_NAME: 'Bridge Storage Arts & Events',


### PR DESCRIPTION
## Summary
- Update `js/config.js` API_BASE from localhost to Railway production URL
- Enables live API data on the Netlify-hosted site

## Note
Requires `CORS_EXTRA_ORIGINS=https://bridge-storage.netlify.app` set in Railway dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)