### PR TITLE
fix: proxy API through Netlify to fix iOS cert errors

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,2 @@
+# Proxy API requests through Netlify to avoid cross-origin issues
+/api/*  https://bridge-ai-production-55f9.up.railway.app/public/:splat  200

--- a/index.html
+++ b/index.html
@@ -1598,13 +1598,13 @@
 <script src="js/config.js"></script>
 <script>
 /* ===== API Config ===== */
-const API_BASE = (typeof BRIDGE_CONFIG !== 'undefined' ? BRIDGE_CONFIG.API_BASE : 'http://localhost:8000') + '/public';
+const API_BASE = (typeof BRIDGE_CONFIG !== 'undefined' ? BRIDGE_CONFIG.API_BASE : '') + '/api';
 
 /* ===== Unit API ===== */
 let _unitsCache = null;
 
 async function fetchUnits(params = {}) {
-  const url = new URL(API_BASE + '/units/available.json');
+  const url = new URL(API_BASE + '/units/available.json', window.location.origin);
   Object.entries(params).forEach(([k, v]) => { if (v) url.searchParams.set(k, v); });
   const resp = await fetch(url, { headers: { 'Accept': 'application/json' } });
   if (!resp.ok) throw new Error('API ' + resp.status);

--- a/js/config.js
+++ b/js/config.js
@@ -3,7 +3,7 @@ const BRIDGE_CONFIG = {
     // API base URL
     // Production: https://bridge-ai-production-55f9.up.railway.app
     // Local dev:  http://localhost:8000
-    API_BASE: 'https://bridge-ai-production-55f9.up.railway.app',
+    API_BASE: '',
 
     // Site info
     SITE_NAME: 'Bridge Storage Arts & Events',


### PR DESCRIPTION
## Summary
- Adds Netlify `_redirects` proxy so API calls go through same-origin `/api/*` instead of cross-origin to Railway
- Fixes `ERR_CERT_COMMON_NAME_INVALID` on Brave Browser (iOS) which blocks cross-origin requests
- No behavior change for end users -- same API, just proxied through Netlify

## Changes
- `_redirects`: proxy `/api/*` to Railway `/public/*`
- `js/config.js`: `API_BASE` set to `''` (same origin)
- `index.html`: path changed from `/public` to `/api`, fixed `new URL()` for relative paths