### PR TITLE
fix: 404 after Grab It form submission

### DIFF
--- a/index.html
+++ b/index.html
@@ -1837,7 +1837,9 @@ async function submitGrab(card) {
     });
     const data = await resp.json();
     if (resp.ok) {
-      successEl.innerHTML = '<strong>It\'s yours!</strong> Check your email to finish setup. <a href="' + (data.portal_url || '/portal/') + '" style="color:#DF562A;font-weight:600;">Go to Portal &rarr;</a>';
+      const portalBase = (typeof BRIDGE_CONFIG !== 'undefined' && BRIDGE_CONFIG.PORTAL_BASE) ? BRIDGE_CONFIG.PORTAL_BASE : '';
+      const portalHref = portalBase + (data.portal_url || '/portal/');
+      successEl.innerHTML = '<strong>It\'s yours!</strong> We\'ll be in touch soon. <a href="' + portalHref + '" style="color:#DF562A;font-weight:600;" target="_blank" rel="noopener">Go to Portal &rarr;</a>';
       successEl.style.display = 'block';
       card.querySelector('.grab-form input.grab-name').disabled = true;
       card.querySelector('.grab-form input.grab-email').disabled = true;

--- a/index_clean.html
+++ b/index_clean.html
@@ -1694,7 +1694,9 @@ async function submitGrab(card) {
     });
     const data = await resp.json();
     if (resp.ok) {
-      successEl.innerHTML = '<strong>It\'s yours!</strong> Check your email to finish setup. <a href="' + (data.portal_url || '/portal/') + '" style="color:#DF562A;font-weight:600;">Go to Portal &rarr;</a>';
+      const portalBase = (typeof BRIDGE_CONFIG !== 'undefined' && BRIDGE_CONFIG.PORTAL_BASE) ? BRIDGE_CONFIG.PORTAL_BASE : '';
+      const portalHref = portalBase + (data.portal_url || '/portal/');
+      successEl.innerHTML = '<strong>It\'s yours!</strong> We\'ll be in touch soon. <a href="' + portalHref + '" style="color:#DF562A;font-weight:600;" target="_blank" rel="noopener">Go to Portal &rarr;</a>';
       successEl.style.display = 'block';
       card.querySelector('.grab-form input.grab-name').disabled = true;
       card.querySelector('.grab-form input.grab-email').disabled = true;

--- a/js/config.js
+++ b/js/config.js
@@ -5,6 +5,11 @@ const BRIDGE_CONFIG = {
     // Local dev:  http://localhost:8000
     API_BASE: '',
 
+    // Portal base URL (bridge-ai Django app, not the static site)
+    // Production: https://bridge-ai-production-55f9.up.railway.app
+    // Local dev:  http://localhost:8000
+    PORTAL_BASE: 'https://bridge-ai-production-55f9.up.railway.app',
+
     // Site info
     SITE_NAME: 'Bridge Storage Arts & Events',
     SITE_URL: 'https://bridgestorage.com',


### PR DESCRIPTION
## Summary
- Portal link in Grab It success message pointed to `/portal/` on the static site (404)
- Added `PORTAL_BASE` config to `js/config.js` pointing to bridge-ai production URL
- Success link now opens bridge-ai portal in a new tab
- Changed success text from "Check your email" to "We'll be in touch soon" (no email is sent yet)

## Related
- Email/SMS confirmation on rental application submission needs to be built on bridge-ai side (separate PR)

## Test plan
- [ ] Submit Grab It form on production site
- [ ] Verify "Go to Portal" link opens bridge-ai portal (no 404)
- [ ] Verify link opens in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)