### PR TITLE
Fix API_BASE URL and /api→/public prefix for Netlify

### DIFF
--- a/index.html
+++ b/index.html
@@ -1535,7 +1535,7 @@
 <script src="js/bridge-modal-booking.js"></script>
 <script>
 /* ===== API Config ===== */
-const API_BASE = (typeof BRIDGE_CONFIG !== 'undefined' ? BRIDGE_CONFIG.API_BASE : '') + '/api';
+const API_BASE = (typeof BRIDGE_CONFIG !== 'undefined' ? BRIDGE_CONFIG.API_BASE : '') + '/public';
 
 /* ===== Unit API ===== */
 let _unitsCache = null;

--- a/js/config.js
+++ b/js/config.js
@@ -3,7 +3,7 @@ const BRIDGE_CONFIG = {
     // API base URL
     // Production: https://bridge-ai-production-55f9.up.railway.app
     // Local dev:  http://localhost:8000
-    API_BASE: '',
+    API_BASE: 'https://bridge-ai-production-55f9.up.railway.app',
 
     // Portal base URL (bridge-ai Django app, not the static site)
     // Production: https://bridge-ai-production-55f9.up.railway.app

--- a/tests/e2e/homepage-forms.spec.ts
+++ b/tests/e2e/homepage-forms.spec.ts
@@ -52,7 +52,7 @@ test.describe('Homepage Forms', () => {
       await indexPage.showScreen('store');
       await expect(indexPage.unitsDynamic).toBeVisible();
       // Register error route AFTER setupMocks so it takes priority (LIFO)
-      await page.route('**/api/units/*/apply/', async (route) => {
+      await page.route('**/public/units/*/apply/', async (route) => {
         await route.fulfill({
           status: 409,
           contentType: 'application/json',

--- a/tests/error-handling/api-down.spec.ts
+++ b/tests/error-handling/api-down.spec.ts
@@ -41,7 +41,7 @@ test.describe('Error Handling: API Down (500)', () => {
     await expect(indexPage.unitsDynamic).toBeVisible();
 
     // Route the apply endpoint to 500
-    await page.route('**/api/units/*/apply/', async (route) => {
+    await page.route('**/public/units/*/apply/', async (route) => {
       await route.fulfill({
         status: 500,
         contentType: 'application/json',

--- a/tests/error-handling/network-errors.spec.ts
+++ b/tests/error-handling/network-errors.spec.ts
@@ -41,7 +41,7 @@ test.describe('Error Handling: Network Errors', () => {
   test('fetch abort does not crash page', async ({ page, withMocks }) => {
     await withMocks();
     // Intercept and abort a request
-    await page.route('**/api/units/available*', (route) => route.abort());
+    await page.route('**/public/units/available*', (route) => route.abort());
     const indexPage = new IndexPage(page);
     await indexPage.goto();
     await indexPage.showScreen('store');

--- a/tests/error-handling/validation-errors.spec.ts
+++ b/tests/error-handling/validation-errors.spec.ts
@@ -64,7 +64,7 @@ test.describe('Error Handling: Validation Errors', () => {
 
   test('API 422 response shows field errors', async ({ page }) => {
     // Route apply to return 422 with field errors
-    await page.route('**/api/units/*/apply/', async (route) => {
+    await page.route('**/public/units/*/apply/', async (route) => {
       await route.fulfill({
         status: 422,
         contentType: 'application/json',

--- a/tests/fixtures/api-mocks.ts
+++ b/tests/fixtures/api-mocks.ts
@@ -32,7 +32,7 @@ export interface MockOverrides {
 
 export async function setupApiMocks(page: Page, overrides: MockOverrides = {}): Promise<void> {
   // Units available endpoint
-  await page.route('**/api/units/available.json*', async (route: Route) => {
+  await page.route('**/public/units/available.json*', async (route: Route) => {
     if (overrides.networkError) {
       await route.abort('connectionrefused');
       return;
@@ -53,7 +53,7 @@ export async function setupApiMocks(page: Page, overrides: MockOverrides = {}): 
   });
 
   // Unit apply (Grab It form)
-  await page.route('**/api/units/*/apply/', async (route: Route) => {
+  await page.route('**/public/units/*/apply/', async (route: Route) => {
     if (overrides.networkError) {
       await route.abort('connectionrefused');
       return;

--- a/tests/forms/grab-it.spec.ts
+++ b/tests/forms/grab-it.spec.ts
@@ -73,7 +73,7 @@ test.describe('Grab It Forms', () => {
   test('submit calls POST to unit apply API', async ({ page }) => {
     let apiCalled = false;
     let requestBody: any;
-    await page.route('**/api/units/*/apply/', async (route) => {
+    await page.route('**/public/units/*/apply/', async (route) => {
       apiCalled = true;
       requestBody = route.request().postDataJSON();
       await route.fulfill({
@@ -104,7 +104,7 @@ test.describe('Grab It Forms', () => {
     await expect(indexPage.unitsDynamic).toBeVisible();
     // Re-route apply to return 409 (conflict) so resp.ok is false
     // Registered AFTER setupMocks so this takes priority (LIFO)
-    await page.route('**/api/units/*/apply/', async (route) => {
+    await page.route('**/public/units/*/apply/', async (route) => {
       await route.fulfill({
         status: 409,
         contentType: 'application/json',


### PR DESCRIPTION
## Summary
- Set `API_BASE` in `config.js` to Railway production backend URL (`https://bridge-ai-production-55f9.up.railway.app`)
- Fix `index.html` inline JS to use `/public` prefix instead of `/api` (matching backend URL structure)
- Update all test mock route patterns from `**/api/units/**` to `**/public/units/**`

## Root Cause
Netlify deploy had no working API calls because:
1. `API_BASE` was empty string — requests went to Netlify origin (no backend)
2. Even with correct base, `/api` prefix didn't match backend's `/public/` mount point

## Test plan
- [x] Full Playwright suite passes (219 passed, 0 failed)
- [ ] Verify Netlify deploy preview shows unit cards loading on Store screen
- [ ] Verify space calendars render on booking pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)