### PR TITLE
Fix gallery resource ID to match production database

### DIFF
--- a/index.html
+++ b/index.html
@@ -1159,7 +1159,7 @@
 
   <!-- Storage Rental (multi-step: select → info → payment → confirmation) -->
   <!-- Booking: Gallery (self-booking with calendar + payment) -->
-  <div class="modal-overlay" id="modal-booking-gallery" data-resource-id="700a7529-c203-4914-a228-47131e63338c" data-resource-key="gallery" data-space-page="spaces/gallery.html" onclick="if(event.target===this)closeModal()">
+  <div class="modal-overlay" id="modal-booking-gallery" data-resource-id="b6240b45-54a8-44d5-934e-add2ab04d141" data-resource-key="gallery" data-space-page="spaces/gallery.html" onclick="if(event.target===this)closeModal()">
     <div class="modal-sheet">
       <div class="modal-handle"></div>
       <div id="gallery-step-1">

--- a/spaces/gallery.html
+++ b/spaces/gallery.html
@@ -83,7 +83,7 @@
     <h2 class="text-2xl font-bold mb-2">Availability</h2>
     <p id="calendar-hint" class="text-sm text-gray-500 mb-4 hidden">Tap a date to see available times.</p>
     <p id="calendar-error" class="text-sm text-red-600 mb-4 hidden"></p>
-    <div id="space-calendar" data-resource-id="700a7529-c203-4914-a228-47131e63338c" data-resource-key="gallery"></div>
+    <div id="space-calendar" data-resource-id="b6240b45-54a8-44d5-934e-add2ab04d141" data-resource-key="gallery"></div>
 </section>
 
 <!-- Invoice Modal -->

--- a/tests/forms/booking-calendar.spec.ts
+++ b/tests/forms/booking-calendar.spec.ts
@@ -23,7 +23,7 @@ test.describe('Gallery Page - Calendar Booking', () => {
 
   test('calendar container has resource attributes', async ({ page }) => {
     const calEl = page.locator('#space-calendar');
-    await expect(calEl).toHaveAttribute('data-resource-id', '700a7529-c203-4914-a228-47131e63338c');
+    await expect(calEl).toHaveAttribute('data-resource-id', 'b6240b45-54a8-44d5-934e-add2ab04d141');
     await expect(calEl).toHaveAttribute('data-resource-key', 'gallery');
   });
 

--- a/tests/forms/modal-time-grid.spec.ts
+++ b/tests/forms/modal-time-grid.spec.ts
@@ -18,7 +18,7 @@ test.describe('Modal Time Grid Structure (Phase 4)', () => {
 
   test('gallery modal has data-resource-id attribute', async ({ page }) => {
     const modal = page.locator('#modal-booking-gallery');
-    await expect(modal).toHaveAttribute('data-resource-id', '700a7529-c203-4914-a228-47131e63338c');
+    await expect(modal).toHaveAttribute('data-resource-id', 'b6240b45-54a8-44d5-934e-add2ab04d141');
   });
 
   test('gallery modal has data-resource-key attribute', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Updated gallery resource ID from placeholder UUID to actual production database UUID (`b6240b45-54a8-44d5-934e-add2ab04d141`)
- Fixed in `index.html`, `spaces/gallery.html`, and corresponding test files
- This resolves the 404 on `options.json` and `calendar.json` that prevented the booking modal calendar from rendering

## Test plan
- [x] Verified locally: "Book The Gallery" modal shows month calendar with availability
- [x] Verified API: `options.json` and `calendar.json` return valid JSON for this resource ID
- [ ] CI tests pass
- [ ] Verify on Netlify deploy preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)