### PR TITLE
feat(spaces): remove warrior SVG and collapse calendar on date selection

### DIFF
--- a/.claude/job-tracker.json
+++ b/.claude/job-tracker.json
@@ -1,0 +1,1 @@
+{"currentJob": {"number": 38, "repo": "jhwright/bridge-prototype", "createdAt": "2026-03-05T00:00:00Z"}}

--- a/index.html
+++ b/index.html
@@ -211,6 +211,11 @@
   .cal-day.selected { background: #DF562A; color: #fff; font-weight: 700; }
   .cal-day.today { border: 1px solid #DF562A; }
   .cal-legend { display: flex; gap: 16px; font-size: 10px; color: #8a7e72; margin-bottom: 16px; }
+  .booking-cal-grid { max-height: 600px; overflow: hidden; transition: max-height 0.3s ease; }
+  .booking-cal-grid.collapsed { max-height: 0; }
+  .booking-cal-grid.collapsed + .cal-legend { display: none; }
+  .selected-date-bar { display: flex; align-items: center; justify-content: space-between; padding: 10px 14px; margin-bottom: 12px; background: rgba(223,86,42,0.06); border: 1.5px solid #DF562A; border-radius: 10px; font-size: 14px; font-weight: 600; color: #2a2520; }
+  .selected-date-bar .change-date-link { color: #DF562A; font-size: 13px; font-weight: 500; cursor: pointer; text-decoration: underline; }
   .cal-legend-dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 4px; vertical-align: middle; }
   .time-slots { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 16px; }
   .time-slot { padding: 8px 14px; border: 1.5px solid #d1ccc5; border-radius: 8px; font-size: 12px; cursor: pointer; transition: all 0.15s; background: #fff; }
@@ -1165,29 +1170,6 @@
       <div id="gallery-step-1">
         <h2>Book The Gallery</h2>
         <div class="modal-sub">Sprung hardwood · Sound system · Lighting rig · Up to 80 guests</div>
-        <div class="form-group"><label>Room Configuration</label>
-          <select id="gallery-config" onchange="updateGalleryPreview(this.value)">
-            <option value="open-floor">Open Floor (dance/yoga/exercise)</option>
-            <option value="chairs">Chairs (ceremony)</option>
-            <option value="round-tables">Round Tables (reception)</option>
-            <option value="rect-tables">Rectangular Tables (banquet)</option>
-            <option value="stage">Stage (performance)</option>
-            <option value="gallery-walk">Gallery Walk (exhibition)</option>
-          </select>
-        </div>
-        <div id="gallery-config-preview" class="config-preview">
-          <svg id="config-preview-open-floor" width="120" height="100" viewBox="0 0 120 100" fill="none" xmlns="http://www.w3.org/2000/svg" class="config-preview-svg">
-            <circle cx="60" cy="14" r="7" stroke="#d64078" stroke-width="2" fill="none"/>
-            <line x1="60" y1="21" x2="60" y2="52" stroke="#d64078" stroke-width="2"/>
-            <line x1="60" y1="30" x2="46" y2="10" stroke="#d64078" stroke-width="2" stroke-linecap="round"/>
-            <line x1="60" y1="30" x2="74" y2="10" stroke="#d64078" stroke-width="2" stroke-linecap="round"/>
-            <line x1="60" y1="52" x2="45" y2="70" stroke="#d64078" stroke-width="2" stroke-linecap="round"/>
-            <line x1="45" y1="70" x2="42" y2="90" stroke="#d64078" stroke-width="2" stroke-linecap="round"/>
-            <line x1="60" y1="52" x2="82" y2="90" stroke="#d64078" stroke-width="2" stroke-linecap="round"/>
-            <line x1="20" y1="92" x2="100" y2="92" stroke="#e5e0db" stroke-width="1"/>
-            <text x="60" y="99" text-anchor="middle" font-size="7" fill="#8a8078" font-family="sans-serif">warrior 1</text>
-          </svg>
-        </div>
         <div class="form-group"><label>Type of event</label>
           <select><option>Dance class / workshop</option><option>Performance / show</option><option>DJ night / party</option><option>Reception / dinner</option><option>Exhibition</option><option>Rehearsal</option><option>Private event</option></select>
         </div>
@@ -1889,11 +1871,6 @@ function showBookingStep(modalPrefix, n) {
     const el = document.getElementById(modalPrefix + '-step-' + i);
     if (el) el.style.display = i === n ? '' : 'none';
   });
-}
-
-function updateGalleryPreview(val) {
-  var el = document.getElementById('gallery-config-preview');
-  if (el) el.style.display = val === 'open-floor' ? '' : 'none';
 }
 
 /* ===== Portal Tab Nav ===== */

--- a/js/bridge-modal-booking.js
+++ b/js/bridge-modal-booking.js
@@ -152,9 +152,65 @@
           el.classList.remove('selected');
         });
         dayEl.classList.add('selected');
+        // Collapse calendar and show date bar
+        collapseCalendar(modalEl);
         renderTimeGrid(modalEl);
       });
     });
+  }
+
+  // --- Calendar Collapse ---
+
+  function collapseCalendar(modalEl) {
+    const state = getState(modalEl);
+    const calGrid = modalEl.querySelector('.booking-cal-grid');
+    if (calGrid) calGrid.classList.add('collapsed');
+
+    // Create or update date bar
+    let dateBar = modalEl.querySelector('.selected-date-bar');
+    if (!dateBar) {
+      dateBar = document.createElement('div');
+      dateBar.className = 'selected-date-bar';
+      // Insert after cal-legend
+      const legend = modalEl.querySelector('.cal-legend');
+      if (legend) {
+        legend.after(dateBar);
+      } else if (calGrid) {
+        calGrid.after(dateBar);
+      }
+    }
+
+    // Format the selected date
+    const parts = state.selectedDate.split('-');
+    const dateObj = new Date(parseInt(parts[0]), parseInt(parts[1]) - 1, parseInt(parts[2]));
+    const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    const formatted = dayNames[dateObj.getDay()] + ' ' + monthNames[dateObj.getMonth()] + ' ' + dateObj.getDate();
+
+    dateBar.innerHTML = '<span>' + formatted + '</span><a class="change-date-link">Change</a>';
+    dateBar.style.display = '';
+
+    // Bind Change link
+    dateBar.querySelector('.change-date-link').addEventListener('click', function () {
+      expandCalendar(modalEl);
+    });
+  }
+
+  function expandCalendar(modalEl) {
+    const state = getState(modalEl);
+    const calGrid = modalEl.querySelector('.booking-cal-grid');
+    if (calGrid) calGrid.classList.remove('collapsed');
+
+    const dateBar = modalEl.querySelector('.selected-date-bar');
+    if (dateBar) dateBar.style.display = 'none';
+
+    // Clear time selection
+    state.selectionStart = null;
+    state.selectionEnd = null;
+    state.isDragging = false;
+    const timeGrid = modalEl.querySelector('.booking-time-grid');
+    if (timeGrid) timeGrid.innerHTML = '';
+    updateContinueButton(modalEl);
   }
 
   // --- Time Grid ---

--- a/tests/forms/modal-time-grid.spec.ts
+++ b/tests/forms/modal-time-grid.spec.ts
@@ -265,3 +265,109 @@ test.describe('Modal Booking Calendar Interaction (Phase 5)', () => {
     await expect(modal.locator('.booking-cal-grid .cal-day').first()).toBeVisible();
   });
 });
+
+test.describe('Gallery Modal Cleanup (PR1)', () => {
+  test.beforeEach(async ({ page, withMocks }) => {
+    await withMocks();
+    await page.goto('/index.html');
+  });
+
+  test('warrior SVG and gallery config preview are removed', async ({ page }) => {
+    await expect(page.locator('#gallery-config-preview')).not.toBeAttached();
+  });
+
+  test('gallery room configuration select is removed', async ({ page }) => {
+    await expect(page.locator('#gallery-config')).not.toBeAttached();
+  });
+});
+
+test.describe('Calendar Collapse on Date Selection (PR1)', () => {
+  test.beforeEach(async ({ page, withMocks }) => {
+    await withMocks();
+    await page.goto('/index.html');
+  });
+
+  test('clicking a date collapses the calendar grid', async ({ page }) => {
+    await openBookingModal(page, 'modal-booking-gallery');
+    const modal = page.locator('#modal-booking-gallery');
+    const calGrid = modal.locator('.booking-cal-grid');
+    // Click a future day
+    await modal.locator('.booking-cal-grid .cal-day:not(.header):not(.past)').filter({ hasText: '10' }).click();
+    await page.waitForTimeout(200);
+    await expect(calGrid).toHaveClass(/collapsed/);
+  });
+
+  test('selected date bar appears after date selection', async ({ page }) => {
+    await openBookingModal(page, 'modal-booking-gallery');
+    const modal = page.locator('#modal-booking-gallery');
+    await modal.locator('.booking-cal-grid .cal-day:not(.header):not(.past)').filter({ hasText: '10' }).click();
+    await page.waitForTimeout(200);
+    const dateBar = modal.locator('.selected-date-bar');
+    await expect(dateBar).toBeVisible();
+    // Should contain the date text
+    await expect(dateBar).toContainText('Mar');
+    await expect(dateBar).toContainText('10');
+  });
+
+  test('selected date bar has a Change link', async ({ page }) => {
+    await openBookingModal(page, 'modal-booking-gallery');
+    const modal = page.locator('#modal-booking-gallery');
+    await modal.locator('.booking-cal-grid .cal-day:not(.header):not(.past)').filter({ hasText: '10' }).click();
+    await page.waitForTimeout(200);
+    const changeLink = modal.locator('.selected-date-bar .change-date-link');
+    await expect(changeLink).toBeVisible();
+    await expect(changeLink).toContainText('Change');
+  });
+
+  test('clicking Change re-expands the calendar', async ({ page }) => {
+    await openBookingModal(page, 'modal-booking-gallery');
+    const modal = page.locator('#modal-booking-gallery');
+    const calGrid = modal.locator('.booking-cal-grid');
+    // Select a date
+    await modal.locator('.booking-cal-grid .cal-day:not(.header):not(.past)').filter({ hasText: '10' }).click();
+    await page.waitForTimeout(200);
+    await expect(calGrid).toHaveClass(/collapsed/);
+    // Click Change
+    await modal.locator('.selected-date-bar .change-date-link').click();
+    await page.waitForTimeout(200);
+    // Calendar should be expanded again
+    await expect(calGrid).not.toHaveClass(/collapsed/);
+  });
+
+  test('clicking Change hides the date bar', async ({ page }) => {
+    await openBookingModal(page, 'modal-booking-gallery');
+    const modal = page.locator('#modal-booking-gallery');
+    await modal.locator('.booking-cal-grid .cal-day:not(.header):not(.past)').filter({ hasText: '10' }).click();
+    await page.waitForTimeout(200);
+    await modal.locator('.selected-date-bar .change-date-link').click();
+    await page.waitForTimeout(200);
+    await expect(modal.locator('.selected-date-bar')).not.toBeVisible();
+  });
+
+  test('clicking Change clears time selection', async ({ page }) => {
+    await openBookingModal(page, 'modal-booking-gallery');
+    const modal = page.locator('#modal-booking-gallery');
+    // Select date and time
+    await modal.locator('.booking-cal-grid .cal-day:not(.header):not(.past)').filter({ hasText: '10' }).click();
+    await page.waitForTimeout(200);
+    const slots = modal.locator('.booking-time-grid .time-grid-slot');
+    await slots.nth(4).dispatchEvent('mousedown');
+    await slots.nth(7).dispatchEvent('mouseover');
+    await slots.nth(7).dispatchEvent('mouseup');
+    // Click Change
+    await modal.locator('.selected-date-bar .change-date-link').click();
+    await page.waitForTimeout(200);
+    // Time grid should be cleared
+    const timeGrid = modal.locator('.booking-time-grid');
+    await expect(timeGrid).toBeEmpty();
+  });
+
+  test('cal-legend is hidden when calendar is collapsed', async ({ page }) => {
+    await openBookingModal(page, 'modal-booking-gallery');
+    const modal = page.locator('#modal-booking-gallery');
+    await modal.locator('.booking-cal-grid .cal-day:not(.header):not(.past)').filter({ hasText: '10' }).click();
+    await page.waitForTimeout(200);
+    const legend = modal.locator('.cal-legend');
+    await expect(legend).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- Remove gallery room configuration select and warrior SVG preview from gallery modal
- Calendar grid collapses after date selection with smooth CSS transition
- Add selected-date-bar showing chosen date with "Change" link to re-expand
- "Change" clears time selection and restores calendar view

## Test plan
- [x] 9 new Playwright tests for PR1 changes (all passing)
- [x] Full desktop test suite: 234 passed, 0 failures
- [ ] Visual verification in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)