### PR TITLE
feat(spaces): inline invoice flow with addons and pricing

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,6 +216,28 @@
   .booking-cal-grid.collapsed + .cal-legend { display: none; }
   .selected-date-bar { display: flex; align-items: center; justify-content: space-between; padding: 10px 14px; margin-bottom: 12px; background: rgba(223,86,42,0.06); border: 1.5px solid #DF562A; border-radius: 10px; font-size: 14px; font-weight: 600; color: #2a2520; }
   .selected-date-bar .change-date-link { color: #DF562A; font-size: 13px; font-weight: 500; cursor: pointer; text-decoration: underline; }
+  .booking-invoice-section { margin-top: 16px; }
+  .booking-invoice-section .addon-option { display: flex; align-items: center; justify-content: space-between; padding: 8px 0; }
+  .booking-invoice-section .addon-option label { display: flex; align-items: center; gap: 8px; cursor: pointer; font-size: 14px; }
+  .booking-invoice-section .addon-option input[type="checkbox"] { width: 16px; height: 16px; accent-color: #DF562A; }
+  .booking-invoice-section .addon-option select { font-size: 13px; border: 1px solid #d1ccc5; border-radius: 8px; padding: 4px 8px; }
+  .booking-invoice-section .addon-option input[type="number"] { width: 60px; font-size: 13px; border: 1px solid #d1ccc5; border-radius: 8px; padding: 4px 8px; text-align: center; }
+  .booking-invoice-section .addon-price-note { font-size: 11px; color: #8a7e72; }
+  .pricing-line { display: flex; justify-content: space-between; align-items: center; padding: 4px 0; font-size: 13px; }
+  .pricing-line.bold { font-weight: 600; }
+  .pricing-line.highlight { color: #DF562A; font-weight: 600; }
+  .pricing-line.discount { color: #16a34a; }
+  .pricing-divider { border-top: 1px solid #e5e0db; margin: 6px 0; }
+  .pricing-divider.thick { border-color: #d1ccc5; }
+  .booking-invoice-section textarea.special-notes { width: 100%; border: 1px solid #d1ccc5; border-radius: 8px; padding: 8px 12px; font-size: 13px; font-family: inherit; resize: vertical; min-height: 60px; }
+  .booking-invoice-section .apply-form { margin-top: 12px; }
+  .booking-invoice-section .apply-form input { width: 100%; border: 1px solid #d1ccc5; border-radius: 8px; padding: 8px 12px; font-size: 13px; font-family: inherit; margin-bottom: 8px; }
+  .booking-invoice-section .btn-apply { width: 100%; padding: 12px; background: #DF562A; color: #fff; border: none; border-radius: 10px; font-size: 15px; font-weight: 600; cursor: pointer; }
+  .booking-invoice-section .btn-apply:disabled { opacity: 0.5; cursor: not-allowed; }
+  .booking-invoice-section .apply-error { color: #dc2626; font-size: 13px; margin-bottom: 8px; display: none; }
+  .booking-confirmation { margin-top: 16px; background: #f0fdf4; border-radius: 12px; padding: 24px; text-align: center; }
+  .booking-confirmation h3 { font-size: 18px; font-weight: 700; margin-bottom: 8px; color: #2a2520; }
+  .booking-confirmation p { font-size: 14px; color: #6b7280; margin-bottom: 12px; }
   .cal-legend-dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 4px; vertical-align: middle; }
   .time-slots { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 16px; }
   .time-slot { padding: 8px 14px; border: 1.5px solid #d1ccc5; border-radius: 8px; font-size: 12px; cursor: pointer; transition: all 0.15s; background: #fff; }
@@ -1182,6 +1204,8 @@
         <div class="form-group"><label>Expected attendance</label><input type="number" placeholder="e.g. 40" max="80"></div>
         <div class="booking-price-calc price-calc"></div>
         <button class="btn-primary btn-continue-booking" disabled>Continue to Booking</button>
+        <div class="booking-invoice-section" style="display:none"></div>
+        <div class="booking-confirmation" style="display:none"></div>
       </div>
     </div>
   </div>
@@ -1202,6 +1226,8 @@
         <div class="form-group"><label>Expected attendance</label><input type="number" placeholder="e.g. 60"></div>
         <div class="booking-price-calc price-calc"></div>
         <button class="btn-primary btn-continue-booking" disabled>Continue to Booking</button>
+        <div class="booking-invoice-section" style="display:none"></div>
+        <div class="booking-confirmation" style="display:none"></div>
       </div>
     </div>
   </div>
@@ -1228,6 +1254,8 @@
         </div>
         <div class="booking-price-calc price-calc"></div>
         <button class="btn-primary btn-continue-booking" disabled>Continue to Booking</button>
+        <div class="booking-invoice-section" style="display:none"></div>
+        <div class="booking-confirmation" style="display:none"></div>
       </div>
     </div>
   </div>
@@ -1284,6 +1312,8 @@
         <div class="form-group"><label>Expected attendance</label><input type="number" placeholder="e.g. 15" max="30"></div>
         <div class="booking-price-calc price-calc"></div>
         <button class="btn-primary btn-continue-booking" disabled>Continue to Booking</button>
+        <div class="booking-invoice-section" style="display:none"></div>
+        <div class="booking-confirmation" style="display:none"></div>
       </div>
     </div>
   </div>

--- a/js/bridge-modal-booking.js
+++ b/js/bridge-modal-booking.js
@@ -26,6 +26,8 @@
         selectionStart: null,
         selectionEnd: null,
         isDragging: false,
+        optionValues: {},
+        pricing: null,
       };
     }
     return modalStates[id];
@@ -380,6 +382,14 @@
     if (!btn) return;
     const hasSelection = state.selectionStart !== null && state.selectionEnd !== null;
     btn.disabled = !hasSelection;
+
+    if (hasSelection) {
+      const lo = Math.min(state.selectionStart, state.selectionEnd);
+      const hi = Math.max(state.selectionStart, state.selectionEnd) + SLOT_MINUTES;
+      btn.textContent = formatTime(lo) + ' – ' + formatTime(hi) + '  ·  Continue';
+    } else {
+      btn.textContent = 'Continue to Booking';
+    }
   }
 
   // --- Helpers ---
@@ -403,21 +413,253 @@
   function handleContinue(modalEl) {
     const state = getState(modalEl);
     if (!state.selectedDate || state.selectionStart === null || state.selectionEnd === null) return;
-
-    const lo = Math.min(state.selectionStart, state.selectionEnd);
-    const hi = Math.max(state.selectionStart, state.selectionEnd) + SLOT_MINUTES;
-
-    const startTime = minutesToTimeStr(lo);
-    const endTime = minutesToTimeStr(hi);
-
-    const url = `${state.spacePage}?date=${state.selectedDate}&start=${startTime}&end=${endTime}`;
-    window.location.href = url;
+    showInvoice(modalEl);
   }
 
   function minutesToTimeStr(totalMinutes) {
     const h = Math.floor(totalMinutes / 60);
     const m = totalMinutes % 60;
     return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+  }
+
+  function formatCurrency(amount) {
+    return '$' + Number(amount).toFixed(2);
+  }
+
+  // --- Inline Invoice ---
+
+  function showInvoice(modalEl) {
+    const state = getState(modalEl);
+    const section = modalEl.querySelector('.booking-invoice-section');
+    if (!section) return;
+
+    // Initialize option default values
+    if (state.options && state.options.options) {
+      for (var opt of state.options.options) {
+        if (!(opt.key in state.optionValues)) {
+          state.optionValues[opt.key] = opt.default !== undefined ? opt.default : (opt.type === 'toggle' ? false : '');
+        }
+      }
+    }
+
+    section.style.display = '';
+    renderInvoiceContent(modalEl);
+    fetchAndRenderPricing(modalEl);
+  }
+
+  function renderInvoiceContent(modalEl) {
+    const state = getState(modalEl);
+    const section = modalEl.querySelector('.booking-invoice-section');
+    if (!section) return;
+
+    let html = '';
+
+    // Addons
+    if (state.options && state.options.options && state.options.options.length > 0) {
+      html += '<h4 style="font-size:14px;font-weight:600;margin-bottom:8px">Add-Ons</h4>';
+      for (var opt of state.options.options) {
+        if (opt.depends_on && !state.optionValues[opt.depends_on]) continue;
+
+        html += '<div class="addon-option">';
+        if (opt.type === 'toggle') {
+          html += '<label><input type="checkbox" data-addon-key="' + opt.key + '"'
+            + (state.optionValues[opt.key] ? ' checked' : '') + '>'
+            + '<span>' + opt.label + '</span></label>';
+          if (opt.price_note) html += '<span class="addon-price-note">' + opt.price_note + '</span>';
+        } else if (opt.type === 'select') {
+          html += '<label>' + opt.label + '</label><select data-addon-key="' + opt.key + '">';
+          for (var c of (opt.choices || [])) {
+            html += '<option value="' + c.value + '"'
+              + (state.optionValues[opt.key] === c.value ? ' selected' : '') + '>'
+              + c.label + '</option>';
+          }
+          html += '</select>';
+          if (opt.price_note) html += '<span class="addon-price-note">' + opt.price_note + '</span>';
+        } else if (opt.type === 'number') {
+          html += '<label>' + opt.label + '</label>';
+          html += '<input type="number" min="0" data-addon-key="' + opt.key + '" value="' + (state.optionValues[opt.key] || 0) + '">';
+        }
+        html += '</div>';
+      }
+    }
+
+    // Pricing lines container
+    html += '<div class="pricing-lines" style="margin-top:12px"></div>';
+
+    // Special notes
+    html += '<div style="margin-top:12px"><label style="font-size:13px;font-weight:500">Special Notes</label>';
+    html += '<textarea class="special-notes" placeholder="Any special requests or event details..."></textarea></div>';
+
+    // Apply form
+    html += '<div class="apply-form">';
+    html += '<div class="apply-error"></div>';
+    html += '<input class="apply-name" type="text" placeholder="Your name">';
+    html += '<input class="apply-email" type="email" placeholder="Email address">';
+    html += '<button class="btn-apply" type="button">Submit Application</button>';
+    html += '</div>';
+
+    section.innerHTML = html;
+
+    // Bind addon change events
+    section.querySelectorAll('[data-addon-key]').forEach(function (el) {
+      el.addEventListener('change', function () {
+        var key = el.dataset.addonKey;
+        if (el.type === 'checkbox') {
+          state.optionValues[key] = el.checked;
+        } else if (el.type === 'number') {
+          state.optionValues[key] = parseInt(el.value, 10) || 0;
+        } else {
+          state.optionValues[key] = el.value;
+        }
+        renderInvoiceContent(modalEl);
+        fetchAndRenderPricing(modalEl);
+      });
+    });
+
+    // Bind apply button
+    var applyBtn = section.querySelector('.btn-apply');
+    if (applyBtn) {
+      applyBtn.addEventListener('click', function () {
+        submitApplication(modalEl);
+      });
+    }
+  }
+
+  async function fetchAndRenderPricing(modalEl) {
+    const state = getState(modalEl);
+    const section = modalEl.querySelector('.booking-invoice-section');
+    if (!section) return;
+    const pricingEl = section.querySelector('.pricing-lines');
+    if (!pricingEl) return;
+
+    const lo = Math.min(state.selectionStart, state.selectionEnd);
+    const hi = Math.max(state.selectionStart, state.selectionEnd) + SLOT_MINUTES;
+    const startTime = minutesToTimeStr(lo);
+    const endTime = minutesToTimeStr(hi);
+
+    var body = {
+      start_at: state.selectedDate + 'T' + startTime + ':00',
+      end_at: state.selectedDate + 'T' + endTime + ':00',
+    };
+    for (var key in state.optionValues) {
+      body[key] = state.optionValues[key];
+    }
+
+    try {
+      var url = BRIDGE_CONFIG.API_BASE + '/public/spaces/' + state.resourceId + '/calculate-price/';
+      var res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      var pricing = await res.json();
+      state.pricing = pricing;
+      renderPricingLines(pricingEl, pricing);
+    } catch (err) {
+      console.error('[bridge-modal-booking] Pricing error:', err);
+      pricingEl.innerHTML = '<p style="color:#dc2626;font-size:13px">Could not calculate pricing.</p>';
+    }
+  }
+
+  function renderPricingLines(el, p) {
+    var html = '';
+    html += pricingLine('Base rental', p.hours + ' hrs × ' + formatCurrency(p.hourly_rate) + '/hr', p.base_rental);
+    if (p.peak_amount > 0) html += pricingLine('Peak surcharge', '', p.peak_amount);
+    if (p.bar_amount > 0) html += pricingLine('Bar service', '', p.bar_amount);
+    if (p.snack_amount > 0) html += pricingLine('Snacks', '', p.snack_amount);
+    if (p.stage_amount > 0) html += pricingLine('Stage', '', p.stage_amount);
+    if (p.curtain_amount > 0) html += pricingLine('Privacy curtains', '', p.curtain_amount);
+    if (p.setup_amount > 0) html += pricingLine('Setup', '', p.setup_amount);
+    if (p.teardown_amount > 0) html += pricingLine('Teardown', '', p.teardown_amount);
+
+    html += '<div class="pricing-divider"></div>';
+    html += pricingLine('Subtotal', '', p.subtotal, true);
+
+    if (p.discount_amount > 0) {
+      html += pricingLine('Promo discount', '', -p.discount_amount, false, 'discount');
+    }
+
+    html += '<div class="pricing-divider thick"></div>';
+    html += pricingLine('Deposit (' + p.deposit_percentage + '%)', 'Due at booking', p.deposit_amount, true, 'highlight');
+    html += pricingLine('Balance due', 'At event', p.balance_due);
+
+    el.innerHTML = html;
+  }
+
+  function pricingLine(label, detail, amount, bold, cls) {
+    var classes = 'pricing-line';
+    if (bold) classes += ' bold';
+    if (cls) classes += ' ' + cls;
+    var sign = amount < 0 ? '-' : '';
+    return '<div class="' + classes + '">'
+      + '<div><span>' + label + '</span>'
+      + (detail ? '<span style="font-size:11px;color:#8a7e72;margin-left:4px">' + detail + '</span>' : '')
+      + '</div>'
+      + '<span>' + sign + formatCurrency(Math.abs(amount)) + '</span>'
+      + '</div>';
+  }
+
+  async function submitApplication(modalEl) {
+    const state = getState(modalEl);
+    const section = modalEl.querySelector('.booking-invoice-section');
+    if (!section) return;
+
+    var applyBtn = section.querySelector('.btn-apply');
+    var errEl = section.querySelector('.apply-error');
+    if (applyBtn) {
+      applyBtn.disabled = true;
+      applyBtn.textContent = 'Submitting...';
+    }
+    if (errEl) errEl.style.display = 'none';
+
+    var lo = Math.min(state.selectionStart, state.selectionEnd);
+    var hi = Math.max(state.selectionStart, state.selectionEnd) + SLOT_MINUTES;
+    var startTime = minutesToTimeStr(lo);
+    var endTime = minutesToTimeStr(hi);
+
+    var data = {
+      last_name: (section.querySelector('.apply-name') || {}).value || '',
+      email: (section.querySelector('.apply-email') || {}).value || '',
+      event_description: (section.querySelector('.special-notes') || {}).value || '',
+      selected_dates: [{
+        start: state.selectedDate + 'T' + startTime + ':00',
+        end: state.selectedDate + 'T' + endTime + ':00',
+      }],
+    };
+
+    for (var key in state.optionValues) {
+      data[key] = state.optionValues[key];
+    }
+
+    try {
+      var url = BRIDGE_CONFIG.API_BASE + '/public/spaces/' + state.resourceId + '/apply/';
+      var res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      var result = await res.json();
+      if (!res.ok) throw new Error(result.error || 'Application failed');
+
+      // Hide invoice, show confirmation
+      section.style.display = 'none';
+      var confirmation = modalEl.querySelector('.booking-confirmation');
+      if (confirmation) {
+        confirmation.style.display = '';
+        confirmation.innerHTML = '<h3>Application Submitted!</h3>'
+          + '<p>We\'ll review your request and get back to you shortly.</p>'
+          + '<p style="font-size:12px;color:#9ca3af">Reference: ' + (result.application_id || '') + '</p>';
+      }
+    } catch (err) {
+      if (errEl) {
+        errEl.textContent = err.message;
+        errEl.style.display = '';
+      }
+      if (applyBtn) {
+        applyBtn.disabled = false;
+        applyBtn.textContent = 'Submit Application';
+      }
+    }
   }
 
   // --- Init ---

--- a/tests/forms/modal-time-grid.spec.ts
+++ b/tests/forms/modal-time-grid.spec.ts
@@ -238,7 +238,7 @@ test.describe('Modal Booking Calendar Interaction (Phase 5)', () => {
     expect(count).toBeLessThanOrEqual(2);
   });
 
-  test('continue button enables after selection and redirects', async ({ page }) => {
+  test('continue button enables after selection and shows invoice', async ({ page }) => {
     await openBookingModal(page, 'modal-booking-gallery');
     const modal = page.locator('#modal-booking-gallery');
     // Click day 10
@@ -252,11 +252,13 @@ test.describe('Modal Booking Calendar Interaction (Phase 5)', () => {
     // Continue button should be enabled
     const btn = modal.locator('.btn-continue-booking');
     await expect(btn).toBeEnabled();
-    // Click and check navigation
-    const [response] = await Promise.all([
-      page.waitForURL(/spaces\/gallery\.html\?date=.*&start=.*&end=.*/),
-      btn.click(),
-    ]);
+    // Click continue — should show invoice section (not redirect)
+    await btn.click();
+    await page.waitForTimeout(500);
+    const invoice = modal.locator('.booking-invoice-section');
+    await expect(invoice).toBeVisible();
+    // Should NOT have navigated away
+    expect(page.url()).toContain('/index.html');
   });
 
   test('courtyard modal also initializes calendar on open', async ({ page }) => {
@@ -369,5 +371,116 @@ test.describe('Calendar Collapse on Date Selection (PR1)', () => {
     await page.waitForTimeout(200);
     const legend = modal.locator('.cal-legend');
     await expect(legend).not.toBeVisible();
+  });
+});
+
+// Helper: select date + time range, then click Continue to open invoice
+async function openInvoiceInModal(page: import('@playwright/test').Page, modalId: string) {
+  await openBookingModal(page, modalId);
+  const modal = page.locator('#' + modalId);
+  await modal.locator('.booking-cal-grid .cal-day:not(.header):not(.past)').filter({ hasText: '10' }).click();
+  await page.waitForTimeout(200);
+  const slots = modal.locator('.booking-time-grid .time-grid-slot');
+  await slots.nth(4).dispatchEvent('mousedown');
+  await slots.nth(7).dispatchEvent('mouseover');
+  await slots.nth(7).dispatchEvent('mouseup');
+  await modal.locator('.btn-continue-booking').click();
+  await page.waitForTimeout(500);
+  return modal;
+}
+
+test.describe('Inline Invoice Flow (PR2)', () => {
+  test.beforeEach(async ({ page, withMocks }) => {
+    await withMocks();
+    await page.goto('/index.html');
+  });
+
+  test('continue button text shows selected date and time', async ({ page }) => {
+    await openBookingModal(page, 'modal-booking-gallery');
+    const modal = page.locator('#modal-booking-gallery');
+    await modal.locator('.booking-cal-grid .cal-day:not(.header):not(.past)').filter({ hasText: '10' }).click();
+    await page.waitForTimeout(200);
+    const slots = modal.locator('.booking-time-grid .time-grid-slot');
+    await slots.nth(4).dispatchEvent('mousedown');
+    await slots.nth(7).dispatchEvent('mouseover');
+    await slots.nth(7).dispatchEvent('mouseup');
+    const btn = modal.locator('.btn-continue-booking');
+    // Button should show date/time info instead of generic text
+    const btnText = await btn.textContent();
+    expect(btnText).toContain('10:00');
+  });
+
+  test('invoice section shows pricing lines after continue', async ({ page }) => {
+    const modal = await openInvoiceInModal(page, 'modal-booking-gallery');
+    const pricingLines = modal.locator('.booking-invoice-section .pricing-line');
+    await expect(pricingLines.first()).toBeVisible();
+  });
+
+  test('invoice shows base rental line', async ({ page }) => {
+    const modal = await openInvoiceInModal(page, 'modal-booking-gallery');
+    await expect(modal.locator('.booking-invoice-section')).toContainText('Base rental');
+  });
+
+  test('invoice shows deposit amount', async ({ page }) => {
+    const modal = await openInvoiceInModal(page, 'modal-booking-gallery');
+    await expect(modal.locator('.booking-invoice-section')).toContainText('Deposit');
+  });
+
+  test('gallery modal shows addon options', async ({ page }) => {
+    const modal = await openInvoiceInModal(page, 'modal-booking-gallery');
+    const addons = modal.locator('.booking-invoice-section .addon-option');
+    // Gallery has bar_service, include_snacks, include_stage, privacy_curtains
+    const count = await addons.count();
+    expect(count).toBeGreaterThanOrEqual(3);
+  });
+
+  test('toggling an addon triggers price recalculation', async ({ page }) => {
+    const modal = await openInvoiceInModal(page, 'modal-booking-gallery');
+    // Find a toggle addon and click it
+    const toggle = modal.locator('.booking-invoice-section .addon-option input[type="checkbox"]').first();
+    await toggle.check();
+    await page.waitForTimeout(500);
+    // Pricing should still be visible (recalculated)
+    await expect(modal.locator('.booking-invoice-section')).toContainText('Base rental');
+  });
+
+  test('invoice shows special notes textarea', async ({ page }) => {
+    const modal = await openInvoiceInModal(page, 'modal-booking-gallery');
+    const notes = modal.locator('.booking-invoice-section textarea.special-notes');
+    await expect(notes).toBeVisible();
+  });
+
+  test('invoice shows apply button', async ({ page }) => {
+    const modal = await openInvoiceInModal(page, 'modal-booking-gallery');
+    const applyBtn = modal.locator('.booking-invoice-section .btn-apply');
+    await expect(applyBtn).toBeVisible();
+  });
+
+  test('apply button submits application and shows confirmation', async ({ page }) => {
+    const modal = await openInvoiceInModal(page, 'modal-booking-gallery');
+    // Fill required fields
+    await modal.locator('.booking-invoice-section input.apply-name').fill('Test User');
+    await modal.locator('.booking-invoice-section input.apply-email').fill('test@example.com');
+    // Click apply
+    await modal.locator('.booking-invoice-section .btn-apply').click();
+    await page.waitForTimeout(500);
+    // Should show success confirmation
+    await expect(modal.locator('.booking-confirmation')).toBeVisible();
+    await expect(modal.locator('.booking-confirmation')).toContainText('Application Submitted');
+  });
+
+  test('courtyard modal shows invoice on continue', async ({ page }) => {
+    const modal = await openInvoiceInModal(page, 'modal-booking-outdoor');
+    await expect(modal.locator('.booking-invoice-section')).toBeVisible();
+  });
+
+  test('kitchen modal shows invoice on continue', async ({ page }) => {
+    const modal = await openInvoiceInModal(page, 'modal-membership-kitchen');
+    await expect(modal.locator('.booking-invoice-section')).toBeVisible();
+  });
+
+  test('lounge modal shows invoice on continue', async ({ page }) => {
+    const modal = await openInvoiceInModal(page, 'modal-booking-lounge');
+    await expect(modal.locator('.booking-invoice-section')).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- Replace booking modal redirect with inline invoice flow showing addons, live pricing, and apply form
- Continue button now shows selected time range (e.g. "10:00 AM – 12:00 PM · Continue")
- Add-on options rendered from options API (bar service, snacks, stage, curtains)
- Pricing calculated via calculate-price endpoint and displayed as line items
- Apply form submits to apply endpoint, shows confirmation on success
- All 4 booking modals (gallery, courtyard, kitchen, lounge) support the inline flow
- 13 new Playwright tests for the invoice flow (all passing)

## Test plan
- [x] `npx playwright test tests/forms/modal-time-grid.spec.ts --project=desktop` — 53/54 pass (1 pre-existing flaky test)
- [x] Full suite: 245 passed, 44 skipped, 1 pre-existing failure
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)